### PR TITLE
chore(deps): bump Django to 6.0.6 and Pillow to 12.2.0 (security)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.42.5
-Django==6.0
+Django==6.0.6
 django-cors-headers==4.9.0
 django-storages==1.14.6
 django-stubs-ext==5.2.8
@@ -9,7 +9,7 @@ drf-yasg[validation]==1.21.11
 eth-typing==5.2.1
 eth-utils==5.3.1
 gunicorn==23.0.0
-Pillow==12.0.0
+Pillow==12.2.0
 psycopg2-binary==2.9.11
 requests==2.32.5
 safe-eth-py[django]==7.17.0


### PR DESCRIPTION
## Summary

Security dependency bumps for safe-config-service (no rollout).

- **HIGH** — Django `6.0` → `6.0.6`: includes two SQL injection fixes (CVE-2026-1287, CVE-2026-1312).
- **HIGH** — Pillow `12.0.0` → `12.2.0`: image-parser memory corruption fix (config-service processes chain logos / app icons).

## Notes

- Only `requirements.txt` version pins were changed. No rollout to new service versions.